### PR TITLE
Add missing Ves.UI references and imports

### DIFF
--- a/Ves.UI/Program.cs
+++ b/Ves.UI/Program.cs
@@ -1,4 +1,7 @@
+using Ves.DAL.Data;
+using Ves.Domain.Configuration;
 using Ves.BLL.Services;
+using Ves.Services.Diagnostics;
 using Ves.DAL.Config;
 using Ves.DAL.Repositories;
 using Ves.Services.Implementations;

--- a/Ves.UI/Ves.UI.csproj
+++ b/Ves.UI/Ves.UI.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../Ves.BLL/Ves.BLL.csproj" />
+    <ProjectReference Include="../Ves.DAL/Ves.DAL.csproj" />
     <ProjectReference Include="../Ves.Domain/Ves.Domain.csproj" />
     <ProjectReference Include="../Ves.Services/Ves.Services.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add Ves.DAL as a project reference in Ves.UI
- import the required Ves namespaces in Program.cs

## Testing
- `dotnet restore` *(fails: `dotnet` command not found in container)*
- `dotnet build` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d725c398832a9c240a70132d16fb