### PR TITLE
Refine aggregated product handling in order service

### DIFF
--- a/Ves.BLL.Tests/OrderServiceTests.cs
+++ b/Ves.BLL.Tests/OrderServiceTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Ves.BLL.Requests;
+using Ves.BLL.Services;
+using Ves.DAL.Interfaces;
+using Ves.Domain.Entities;
+using Ves.Domain.ValueObjects;
+using Ves.Services.Interfaces;
+using Xunit;
+
+namespace Ves.BLL.Tests;
+
+public class OrderServiceTests
+{
+    [Fact]
+    public void CreateOrder_AggregatesQuantities_WhenProductIsRepeated()
+    {
+        // Arrange
+        var product = new Product
+        {
+            Id = 1,
+            Name = "Producto de prueba",
+            UnitPrice = new Money(10m, "USD"),
+            Stock = new Quantity(10)
+        };
+
+        var initialStock = product.Stock.Value;
+
+        var productRepository = new FakeProductRepository(product);
+        var orderRepository = new FakeOrderRepository();
+        var detailRepository = new FakeOrderDetailRepository();
+        var unitOfWork = new FakeUnitOfWork();
+        var audit = new FakeAuditService();
+        var service = new OrderService(orderRepository, detailRepository, productRepository, unitOfWork, audit);
+
+        var request = new CreateOrderRequest
+        {
+            ClientId = 42,
+            Details = new[]
+            {
+                new CreateOrderDetailRequest(product.Id, new Quantity(2)),
+                new CreateOrderDetailRequest(product.Id, new Quantity(3))
+            }
+        };
+
+        // Act
+        var order = service.CreateOrder(request);
+
+        // Assert
+        Assert.Equal(1, productRepository.LoadCounts[product.Id]);
+        Assert.Single(productRepository.UpdateStockCalls);
+        Assert.Equal(5, productRepository.UpdateStockCalls[0].Quantity.Value);
+        Assert.All(detailRepository.AddedDetails, d => Assert.Equal(product.Id, d.ProductId));
+        Assert.Equal(2, detailRepository.AddedDetails.Count);
+        Assert.Equal(2, order.Details.Count);
+        Assert.True(unitOfWork.Began);
+        Assert.True(unitOfWork.Committed);
+        Assert.Equal(initialStock - 5, product.Stock.Value);
+
+        var auditEntry = Assert.Single(audit.Entries);
+        Assert.Equal("OrderService", auditEntry.Actor);
+        Assert.Equal("Order.Create", auditEntry.Action);
+        var totalsProperty = auditEntry.Data?.GetType().GetProperty("TotalsByProduct");
+        var totals = Assert.IsAssignableFrom<IEnumerable>(totalsProperty?.GetValue(auditEntry.Data));
+        var perProduct = Assert.Single(totals.Cast<object>());
+        Assert.Equal(product.Id, perProduct?.GetType().GetProperty("ProductId")?.GetValue(perProduct));
+        var requested = perProduct?.GetType().GetProperty("Requested")?.GetValue(perProduct);
+        Assert.Equal(5, Assert.IsType<int>(requested));
+        var stockBefore = perProduct?.GetType().GetProperty("StockBefore")?.GetValue(perProduct);
+        Assert.Equal(initialStock, Assert.IsType<int>(stockBefore));
+        var stockAfter = perProduct?.GetType().GetProperty("StockAfter")?.GetValue(perProduct);
+        Assert.Equal(initialStock - 5, Assert.IsType<int>(stockAfter));
+    }
+
+    private sealed class FakeOrderRepository : IOrderRepository
+    {
+        private int _nextId = 1;
+        public int Create(Order order)
+        {
+            order.Id = _nextId;
+            return _nextId++;
+        }
+    }
+
+    private sealed class FakeOrderDetailRepository : IOrderDetailRepository
+    {
+        public List<OrderDetail> AddedDetails { get; } = new();
+
+        public void Add(OrderDetail detail)
+        {
+            AddedDetails.Add(detail);
+        }
+    }
+
+    private sealed class FakeProductRepository : IProductRepository
+    {
+        private readonly Dictionary<int, Product> _products;
+
+        public FakeProductRepository(params Product[] products)
+        {
+            _products = products.ToDictionary(p => p.Id);
+        }
+
+        public List<(int ProductId, Quantity Quantity)> UpdateStockCalls { get; } = new();
+
+        public Dictionary<int, int> LoadCounts { get; } = new();
+
+        public Product? GetById(int id)
+        {
+            if (_products.TryGetValue(id, out var product))
+            {
+                LoadCounts[id] = LoadCounts.GetValueOrDefault(id) + 1;
+                return product;
+            }
+
+            return null;
+        }
+
+        public void UpdateStock(int id, Quantity quantityToSubtract)
+        {
+            UpdateStockCalls.Add((id, quantityToSubtract));
+            if (_products.TryGetValue(id, out var product))
+            {
+                product.Stock = new Quantity(product.Stock.Value - quantityToSubtract.Value);
+            }
+        }
+    }
+
+    private sealed class FakeUnitOfWork : IUnitOfWork
+    {
+        public bool Began { get; private set; }
+        public bool Committed { get; private set; }
+        public bool RolledBack { get; private set; }
+
+        public void Begin() => Began = true;
+
+        public void Commit() => Committed = true;
+
+        public void Rollback() => RolledBack = true;
+    }
+
+    private sealed class FakeAuditService : IAuditService
+    {
+        public List<AuditEntry> Entries { get; } = new();
+
+        public void Write(string actor, string action, object? data = null)
+        {
+            Entries.Add(new AuditEntry(actor, action, data));
+        }
+
+        public sealed record AuditEntry(string Actor, string Action, object? Data);
+    }
+}

--- a/Ves.BLL.Tests/Ves.BLL.Tests.csproj
+++ b/Ves.BLL.Tests/Ves.BLL.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ves.BLL\Ves.BLL.csproj" />
+    <ProjectReference Include="..\Ves.Domain\Ves.Domain.csproj" />
+    <ProjectReference Include="..\Ves.DAL\Ves.DAL.csproj" />
+    <ProjectReference Include="..\Ves.Services\Ves.Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/Ves.BLL/Interfaces/IOrderService.cs
+++ b/Ves.BLL/Interfaces/IOrderService.cs
@@ -1,0 +1,15 @@
+using Ves.BLL.Requests;
+using Ves.Domain.Entities;
+
+namespace Ves.BLL.Interfaces;
+
+/// <summary>
+/// Exposes use cases related to order management.
+/// </summary>
+public interface IOrderService
+{
+    /// <summary>
+    /// Creates a new order based on the provided request data.
+    /// </summary>
+    Order CreateOrder(CreateOrderRequest request);
+}

--- a/Ves.BLL/Requests/CreateOrderRequest.cs
+++ b/Ves.BLL/Requests/CreateOrderRequest.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Ves.Domain.ValueObjects;
+
+namespace Ves.BLL.Requests;
+
+/// <summary>
+/// Payload describing an order to be created.
+/// </summary>
+public class CreateOrderRequest
+{
+    /// <summary>
+    /// Identifier of the client placing the order.
+    /// </summary>
+    public int ClientId { get; init; }
+
+    /// <summary>
+    /// Collection of requested detail lines.
+    /// </summary>
+    public IReadOnlyCollection<CreateOrderDetailRequest> Details { get; init; } = Array.Empty<CreateOrderDetailRequest>();
+}
+
+/// <summary>
+/// Represents a single detail line in an order creation request.
+/// </summary>
+/// <param name="ProductId">Identifier of the product being ordered.</param>
+/// <param name="Quantity">Requested quantity.</param>
+public record CreateOrderDetailRequest(int ProductId, Quantity Quantity);

--- a/Ves.BLL/Services/OrderService.cs
+++ b/Ves.BLL/Services/OrderService.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ves.BLL.Interfaces;
+using Ves.BLL.Requests;
+using Ves.DAL.Interfaces;
+using Ves.Domain.Entities;
+using Ves.Domain.ValueObjects;
+using Ves.Services.Interfaces;
+
+namespace Ves.BLL.Services;
+
+/// <summary>
+/// Coordinates the creation of orders ensuring stock is respected.
+/// </summary>
+public class OrderService : IOrderService
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly IOrderDetailRepository _orderDetailRepository;
+    private readonly IProductRepository _productRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IAuditService _audit;
+
+    public OrderService(
+        IOrderRepository orderRepository,
+        IOrderDetailRepository orderDetailRepository,
+        IProductRepository productRepository,
+        IUnitOfWork unitOfWork,
+        IAuditService audit)
+    {
+        _orderRepository = orderRepository;
+        _orderDetailRepository = orderDetailRepository;
+        _productRepository = productRepository;
+        _unitOfWork = unitOfWork;
+        _audit = audit;
+    }
+
+    public Order CreateOrder(CreateOrderRequest request)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (request.Details is null || !request.Details.Any())
+        {
+            throw new ArgumentException("Order must include at least one detail.", nameof(request));
+        }
+
+        _unitOfWork.Begin();
+        var order = new Order { ClientId = request.ClientId };
+        var productRequests = new Dictionary<int, ProductRequestState>();
+
+        try
+        {
+            foreach (var detailRequest in request.Details)
+            {
+                var productState = GetOrAddProductState(detailRequest.ProductId, productRequests);
+                var potentialTotal = productState.Requested + detailRequest.Quantity;
+
+                if (potentialTotal.Value > productState.OriginalStock.Value)
+                {
+                    throw new InvalidOperationException(
+                        $"Insufficient stock for product {productState.Product.Id}. " +
+                        $"Requested {potentialTotal.Value} but only {productState.OriginalStock.Value} available.");
+                }
+
+                productState.Register(detailRequest.Quantity);
+
+                var detail = new OrderDetail
+                {
+                    ProductId = detailRequest.ProductId,
+                    Quantity = detailRequest.Quantity,
+                    UnitPrice = productState.Product.UnitPrice
+                };
+
+                order.AddItem(detail);
+            }
+
+            var orderId = _orderRepository.Create(order);
+            order.Id = orderId;
+
+            foreach (var detail in order.Details)
+            {
+                detail.OrderId = orderId;
+                _orderDetailRepository.Add(detail);
+            }
+
+            foreach (var productState in productRequests.Values)
+            {
+                _productRepository.UpdateStock(productState.Product.Id, productState.Requested);
+            }
+
+            _unitOfWork.Commit();
+
+            _audit.Write("OrderService", "Order.Create", new
+            {
+                order.Id,
+                order.ClientId,
+                order.Total,
+                TotalsByProduct = productRequests.Values.Select(state => new
+                {
+                    ProductId = state.Product.Id,
+                    state.Product.Name,
+                    Requested = state.Requested.Value,
+                    StockBefore = state.OriginalStock.Value,
+                    StockAfter = state.RemainingStock.Value
+                }).ToList(),
+                Details = order.Details.Select(d => new
+                {
+                    d.ProductId,
+                    Quantity = d.Quantity.Value,
+                    UnitPrice = d.UnitPrice.Amount,
+                    Subtotal = d.Subtotal().Amount
+                }).ToList()
+            });
+
+            return order;
+        }
+        catch
+        {
+            _unitOfWork.Rollback();
+            throw;
+        }
+    }
+
+    private ProductRequestState GetOrAddProductState(
+        int productId,
+        IDictionary<int, ProductRequestState> productRequests)
+    {
+        if (!productRequests.TryGetValue(productId, out var state))
+        {
+            var product = _productRepository.GetById(productId)
+                ?? throw new InvalidOperationException($"Product {productId} was not found.");
+            state = new ProductRequestState(product);
+            productRequests[productId] = state;
+        }
+
+        return state;
+    }
+
+    private sealed class ProductRequestState
+    {
+        public ProductRequestState(Product product)
+        {
+            Product = product;
+            OriginalStock = product.Stock;
+            Requested = new Quantity(0);
+        }
+
+        public Product Product { get; }
+        public Quantity OriginalStock { get; }
+        public Quantity Requested { get; private set; }
+        public Quantity RemainingStock => OriginalStock - Requested;
+
+        public void Register(Quantity quantity)
+        {
+            Requested = Requested + quantity;
+        }
+    }
+}

--- a/Ves.DAL/Interfaces/IOrderDetailRepository.cs
+++ b/Ves.DAL/Interfaces/IOrderDetailRepository.cs
@@ -1,0 +1,14 @@
+using Ves.Domain.Entities;
+
+namespace Ves.DAL.Interfaces;
+
+/// <summary>
+/// Provides persistence operations for order details.
+/// </summary>
+public interface IOrderDetailRepository
+{
+    /// <summary>
+    /// Adds a detail line to an order.
+    /// </summary>
+    void Add(OrderDetail detail);
+}

--- a/Ves.DAL/Interfaces/IOrderRepository.cs
+++ b/Ves.DAL/Interfaces/IOrderRepository.cs
@@ -1,0 +1,14 @@
+using Ves.Domain.Entities;
+
+namespace Ves.DAL.Interfaces;
+
+/// <summary>
+/// Handles persistence of order aggregates.
+/// </summary>
+public interface IOrderRepository
+{
+    /// <summary>
+    /// Persists an order and returns the generated identifier.
+    /// </summary>
+    int Create(Order order);
+}

--- a/Ves.DAL/Interfaces/IProductRepository.cs
+++ b/Ves.DAL/Interfaces/IProductRepository.cs
@@ -1,0 +1,20 @@
+using Ves.Domain.Entities;
+using Ves.Domain.ValueObjects;
+
+namespace Ves.DAL.Interfaces;
+
+/// <summary>
+/// Provides data access operations for products.
+/// </summary>
+public interface IProductRepository
+{
+    /// <summary>
+    /// Retrieves a product by its identifier.
+    /// </summary>
+    Product? GetById(int id);
+
+    /// <summary>
+    /// Decreases the stock of the product by the provided quantity.
+    /// </summary>
+    void UpdateStock(int id, Quantity quantityToSubtract);
+}

--- a/Ves.sln
+++ b/Ves.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ves.Services", "Ves.Service
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ves.BLL", "Ves.BLL\Ves.BLL.csproj", "{74b8fdbd-ffea-4265-ade6-2fb4c07a38d9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ves.BLL.Tests", "Ves.BLL.Tests\Ves.BLL.Tests.csproj", "{02fec259-a9e7-43ab-84ca-1c7786f099a2}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ves.UI", "Ves.UI\Ves.UI.csproj", "{f8c29245-5cb6-4ee4-8387-c66bbfd853de}"
 EndProject
 Global
@@ -34,6 +36,10 @@ Global
     {74b8fdbd-ffea-4265-ade6-2fb4c07a38d9}.Debug|Any CPU.Build.0 = Debug|Any CPU
     {74b8fdbd-ffea-4265-ade6-2fb4c07a38d9}.Release|Any CPU.ActiveCfg = Release|Any CPU
     {74b8fdbd-ffea-4265-ade6-2fb4c07a38d9}.Release|Any CPU.Build.0 = Release|Any CPU
+    {02fec259-a9e7-43ab-84ca-1c7786f099a2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {02fec259-a9e7-43ab-84ca-1c7786f099a2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {02fec259-a9e7-43ab-84ca-1c7786f099a2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {02fec259-a9e7-43ab-84ca-1c7786f099a2}.Release|Any CPU.Build.0 = Release|Any CPU
     {f8c29245-5cb6-4ee4-8387-c66bbfd853de}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
     {f8c29245-5cb6-4ee4-8387-c66bbfd853de}.Debug|Any CPU.Build.0 = Debug|Any CPU
     {f8c29245-5cb6-4ee4-8387-c66bbfd853de}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
## Summary
- track per-product original stock while creating orders so cumulative requests are validated against availability and logging reports accurate remaining quantities
- update the regression test to assert the aggregated audit payload and resulting stock when a product repeats in an order

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d5daa230832a8344ae0ba143640b