### PR TITLE
Add SQL Server setup scripts and align credentials

### DIFF
--- a/DatabaseScripts/CreateVesDb.sql
+++ b/DatabaseScripts/CreateVesDb.sql
@@ -1,0 +1,53 @@
+-- Script to create the VesDB database, SQL login, and database user
+IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = N'VesDB')
+BEGIN
+    PRINT 'Creating database VesDB';
+    CREATE DATABASE [VesDB];
+END
+ELSE
+BEGIN
+    PRINT 'Database VesDB already exists';
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'test')
+BEGIN
+    PRINT 'Creating SQL login test';
+    CREATE LOGIN [test] WITH PASSWORD = 'test', CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF;
+END
+ELSE
+BEGIN
+    PRINT 'Login test already exists';
+END
+GO
+
+USE [VesDB];
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'test')
+BEGIN
+    PRINT 'Creating database user test for VesDB';
+    CREATE USER [test] FOR LOGIN [test];
+END
+ELSE
+BEGIN
+    PRINT 'Database user test already exists in VesDB';
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.database_role_members drm
+    JOIN sys.database_principals rp ON rp.principal_id = drm.role_principal_id
+    JOIN sys.database_principals mp ON mp.principal_id = drm.member_principal_id
+    WHERE rp.name = N'db_owner' AND mp.name = N'test'
+)
+BEGIN
+    PRINT 'Adding test user to db_owner role in VesDB';
+    ALTER ROLE [db_owner] ADD MEMBER [test];
+END
+ELSE
+BEGIN
+    PRINT 'User test is already member of db_owner role in VesDB';
+END
+GO

--- a/DatabaseScripts/CreateVesHashDb.sql
+++ b/DatabaseScripts/CreateVesHashDb.sql
@@ -1,0 +1,53 @@
+-- Script to create the VesHashDB database and map the shared SQL login
+IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = N'VesHashDB')
+BEGIN
+    PRINT 'Creating database VesHashDB';
+    CREATE DATABASE [VesHashDB];
+END
+ELSE
+BEGIN
+    PRINT 'Database VesHashDB already exists';
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'test')
+BEGIN
+    PRINT 'Creating SQL login test';
+    CREATE LOGIN [test] WITH PASSWORD = 'test', CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF;
+END
+ELSE
+BEGIN
+    PRINT 'Login test already exists';
+END
+GO
+
+USE [VesHashDB];
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'test')
+BEGIN
+    PRINT 'Creating database user test for VesHashDB';
+    CREATE USER [test] FOR LOGIN [test];
+END
+ELSE
+BEGIN
+    PRINT 'Database user test already exists in VesHashDB';
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.database_role_members drm
+    JOIN sys.database_principals rp ON rp.principal_id = drm.role_principal_id
+    JOIN sys.database_principals mp ON mp.principal_id = drm.member_principal_id
+    WHERE rp.name = N'db_owner' AND mp.name = N'test'
+)
+BEGIN
+    PRINT 'Adding test user to db_owner role in VesHashDB';
+    ALTER ROLE [db_owner] ADD MEMBER [test];
+END
+ELSE
+BEGIN
+    PRINT 'User test is already member of db_owner role in VesHashDB';
+END
+GO

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Sistema de gestión VES construido con .NET 8.
 - **Ves.UI**: Aplicación de consola que ejerce como interfaz de usuario.
 
 La solución se orienta a SQL Server 2019 con dos bases de datos: una para datos de negocio y otra para hashes de archivos.
+
+## Scripts de base de datos
+
+En la carpeta `DatabaseScripts` se incluyen los scripts para crear ambas bases de datos (`VesDB` y `VesHashDB`).
+
+Cada script crea la base de datos si no existe, genera el inicio de sesión SQL `test` (con contraseña `test` y las políticas deshabilitadas para aceptar la contraseña simple) y lo agrega como usuario `test` con permisos de `db_owner` en la base correspondiente.

--- a/Ves.UI/Program.cs
+++ b/Ves.UI/Program.cs
@@ -5,8 +5,8 @@ using Ves.Services.Implementations;
 using Ves.Domain.Entities;
 
 // Connection strings for SQL Server 2019 instance
-const string businessCs = "Server=DESKTOP-B7V8BS2\\SQLEXPRESS;Database=VesDB;User Id=ves_user;Password=ves_password;TrustServerCertificate=True;";
-const string hashCs = "Server=DESKTOP-B7V8BS2\\SQLEXPRESS;Database=VesHashDB;User Id=hash_user;Password=hash_password;TrustServerCertificate=True;";
+const string businessCs = "Server=DESKTOP-B7V8BS2\\SQLEXPRESS;Database=VesDB;User Id=test;Password=test;TrustServerCertificate=True;";
+const string hashCs = "Server=DESKTOP-B7V8BS2\\SQLEXPRESS;Database=VesHashDB;User Id=test;Password=test;TrustServerCertificate=True;";
 
 var factory = new SqlConnectionFactory(businessCs, hashCs);
 var clientRepo = new ClientRepository(factory);


### PR DESCRIPTION
## Summary
- add SQL Server scripts to provision VesDB and VesHashDB with the shared `test` login
- update the console application's connection strings to use the new credentials
- document the location and purpose of the database scripts in the README

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f2c87a7c832a81500bab466a0870